### PR TITLE
Use notify-send.sh and attempt at pasting under Wayland

### DIFF
--- a/loq
+++ b/loq
@@ -19,7 +19,7 @@ log_error() {
 
 # Function to display notification
 notify() {
-  NOTIFICATION_ID=$(notify-send "$1" "$2" -e -u critical --print-id -t 0)
+  NOTIFICATION_ID=$(notify-send.sh "$1" "$2" -u critical --print-id -t 0)
   echo $NOTIFICATION_ID >"$TMP_DIR/notification_id"
 }
 
@@ -140,7 +140,9 @@ stop_recording() {
   echo -n "$response" | xclip -sel clip
   
   # Simulate the paste action
-  xdotool key ctrl+v
+  # (this should work in Wayland, but I think that some security sandoboxing
+  # prevents it from doing so)
+  wl-paste
 
   # Close processing response notification
   (sleep $HUD_TIMEOUT && close_notification) &


### PR DESCRIPTION
Thanks for making this script public, it's very useful!

These are two changes to make it work on my system (Gnome on Wayland, Ubuntu 22.04 with minimal customization):

- I think you may be using a custom `notify-send` binary, as mine does not have the `-e` and `--print-id` args. I found this `notify-send.sh` script [here](https://github.com/vlevit/notify-send.sh) which has the latter argument, but not the former. not to mess with the systems' `notify-send` I left the `notify-send.sh` name when putting the script into `/usr/local/bin`. removing the `-e` argument did not seem to affect the functionality in any way
- automatic pasting was not working from me; GPT-4 suggested that Wayland might have some security restrictions on pasting programmatically from a different process. I tried `wl-paste`, which works in a terminal or called directly from a script in the same terminal, but not through `loq` when called through the keyboard shortcut (it works if I run `loq toggle` in a separate terminal, the transcript gets pasted there)

I don't have a solution for the second problem, but thought it would have been good for you to know in case someone else runs into the same problem